### PR TITLE
add: initial visualization node

### DIFF
--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.8)
+project(visualization)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(visualization_msgs REQUIRED)
+
+include_directories(
+  include
+)
+
+add_executable(visualization_exec src/visualization_node.cpp)
+ament_target_dependencies(visualization_exec rclcpp 
+                            std_msgs 
+                            geometry_msgs 
+                            sensor_msgs 
+                            visualization_msgs)
+
+  
+install(TARGETS
+  visualization_exec
+  DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/src/visualization/include/visualization/visualization_node.hpp
+++ b/src/visualization/include/visualization/visualization_node.hpp
@@ -1,0 +1,26 @@
+/**
+ * @file visualization_node.hpp
+ * @brief Visualization node header for ARUS Team Driverless pipeline
+ */
+
+#include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+
+
+/**
+ * @class Visualization
+ * @brief Visualization class 
+ * 
+ * This class represents the pipeline topics through marker messages 
+ * in rviz2
+ */
+class Visualization : public rclcpp::Node
+{
+    public:
+        /**
+         * @brief Constructor for the Visualization class.
+         */
+        Visualization();
+
+};

--- a/src/visualization/package.xml
+++ b/src/visualization/package.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>visualization</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="alplepe02@gmail.com">alvaro</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/visualization/src/visualization_node.cpp
+++ b/src/visualization/src/visualization_node.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file visualization_node.cpp
+ * @brief Visualization node implementaion for ARUS Team Driverless pipeline
+ */
+
+#include "visualization/visualization_node.hpp"
+
+
+/**
+ * @class Visualization
+ * @brief Visualization class 
+ * 
+ * This class represents the pipeline topics through marker messages 
+ * in rviz2
+ */
+Visualization::Visualization() : Node("visualization")
+{
+
+}
+
+int main(int argc, char * argv[])
+{
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<Visualization>());
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
Setup of the visualization node. 
This node will subscribe to all topics that need to be transformed into markers in order to visualize them in rviz.