### PR TITLE
Feature/car state/check supervisor

### DIFF
--- a/src/car_state/config/car_state_config.yaml
+++ b/src/car_state/config/car_state_config.yaml
@@ -2,3 +2,4 @@ car_state:
   ros__parameters:
     get_arussim_ground_truth: false
     simulation: true
+    mission: "autocross"

--- a/src/car_state/include/car_state/car_state.hpp
+++ b/src/car_state/include/car_state/car_state.hpp
@@ -77,15 +77,15 @@ private:
     std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
 
     // Subscribers
-    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_extensometer_;
-    rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_imu_;
-    rclcpp::Subscription<common_msgs::msg::FourWheelDrive>::SharedPtr sub_wheel_speeds_;
-    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_inv_speed_;
-    rclcpp::Subscription<common_msgs::msg::State>::SharedPtr sub_arussim_ground_truth_;
+    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr extensometer_sub_;
+    rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
+    rclcpp::Subscription<common_msgs::msg::FourWheelDrive>::SharedPtr wheel_speeds_sub_;
+    rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr inv_speed_sub_;
+    rclcpp::Subscription<common_msgs::msg::State>::SharedPtr arussim_ground_truth_sub_;
     rclcpp::Subscription<std_msgs::msg::Int16>::SharedPtr as_status_sub_;
 
     // Publisher for the aggregated state
-    rclcpp::Publisher<common_msgs::msg::State>::SharedPtr pub_state_;
+    rclcpp::Publisher<common_msgs::msg::State>::SharedPtr state_pub_;
     rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr as_check_pub_;
 
     // Timer

--- a/src/car_state/include/car_state/car_state.hpp
+++ b/src/car_state/include/car_state/car_state.hpp
@@ -6,6 +6,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/int16.hpp"
+#include "std_msgs/msg/bool.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 #include "common_msgs/msg/state.hpp"
 #include "common_msgs/msg/four_wheel_drive.hpp"
@@ -37,6 +39,7 @@ private:
     void wheel_speeds_callback(const common_msgs::msg::FourWheelDrive::SharedPtr msg);
     void inv_speed_callback(const std_msgs::msg::Float32::SharedPtr msg);
     void arussim_ground_truth_callback(const common_msgs::msg::State::SharedPtr msg);
+    void as_status_callback(const std_msgs::msg::Int16::SharedPtr msg);
 
     // Funtions
     void on_timer();
@@ -59,6 +62,15 @@ private:
 
     Estimation state_estimation_;
     bool kSimulation;
+    std::string kMission;
+
+    // AS status
+    // 0: AS off
+    // 1: AS ready
+    // 2: AS driving
+    // 3: AS finished
+    // 4: AS emergency
+    int as_status_ = 0;
 
     // TF
     std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -70,9 +82,11 @@ private:
     rclcpp::Subscription<common_msgs::msg::FourWheelDrive>::SharedPtr sub_wheel_speeds_;
     rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_inv_speed_;
     rclcpp::Subscription<common_msgs::msg::State>::SharedPtr sub_arussim_ground_truth_;
+    rclcpp::Subscription<std_msgs::msg::Int16>::SharedPtr as_status_sub_;
 
     // Publisher for the aggregated state
     rclcpp::Publisher<common_msgs::msg::State>::SharedPtr pub_state_;
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr as_check_pub_;
 
     // Timer
     rclcpp::TimerBase::SharedPtr timer_;

--- a/src/car_state/src/car_state.cpp
+++ b/src/car_state/src/car_state.cpp
@@ -25,39 +25,39 @@ CarState::CarState(): Node("car_state")
     this->get_parameter("mission", kMission);
 
 
-    pub_state_ = this->create_publisher<common_msgs::msg::State>(
+    state_pub_ = this->create_publisher<common_msgs::msg::State>(
         "/car_state/state", 1);
     as_check_pub_ = this->create_publisher<std_msgs::msg::Bool>(
         "/car_state/AS_check", 1);
 
     if(kSimulation && get_arussim_ground_truth){
-    sub_arussim_ground_truth_ = this->create_subscription<common_msgs::msg::State>(
+    arussim_ground_truth_sub_ = this->create_subscription<common_msgs::msg::State>(
         "/arussim_interface/arussim_ground_truth", 1, std::bind(&CarState::
             arussim_ground_truth_callback, this, std::placeholders::_1));
     }
 
     if(kSimulation){
-        sub_extensometer_ = this->create_subscription<std_msgs::msg::Float32>(
+        extensometer_sub_ = this->create_subscription<std_msgs::msg::Float32>(
             "/arussim/extensometer", 1, std::bind(&CarState::
                 extensometer_callback, this, std::placeholders::_1));
 
-        sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+        imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
             "/arussim/imu", 1, std::bind(&CarState::
                 imu_callback, this, std::placeholders::_1));
 
-        sub_wheel_speeds_ = this->create_subscription<common_msgs::msg::FourWheelDrive>(
+        wheel_speeds_sub_ = this->create_subscription<common_msgs::msg::FourWheelDrive>(
             "/arussim_interface/wheel_speeds", 1, std::bind(&CarState::
                 wheel_speeds_callback, this, std::placeholders::_1));
     } else {
-        sub_extensometer_ = this->create_subscription<std_msgs::msg::Float32>(
+        extensometer_sub_ = this->create_subscription<std_msgs::msg::Float32>(
             "/can/extensometer", 1, std::bind(&CarState::
                 extensometer_callback, this, std::placeholders::_1));
 
-        sub_imu_ = this->create_subscription<sensor_msgs::msg::Imu>(
+        imu_sub_ = this->create_subscription<sensor_msgs::msg::Imu>(
             "/can/IMU", 1, std::bind(&CarState::
                 imu_callback, this, std::placeholders::_1));
 
-        sub_inv_speed_ = this->create_subscription<std_msgs::msg::Float32>(
+        inv_speed_sub_ = this->create_subscription<std_msgs::msg::Float32>(
             "/can/inv_speed", 1, std::bind(&CarState::
                 inv_speed_callback, this, std::placeholders::_1));
         
@@ -146,7 +146,7 @@ void CarState::on_timer()
     state_msg.ay = ay_;
     state_msg.delta = delta_;
 
-    pub_state_->publish(state_msg);
+    state_pub_->publish(state_msg);
 
 
     // Publish AS check


### PR DESCRIPTION
Instead of checking AS_status = 2 in every node, car_state node will act as supervisor and will monitor AS_status and signals from every node. If any of the requirements is not fullfilled it won't send the check to the rest of the nodes